### PR TITLE
Added initial Zurb foundation support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==0.10.1
+Flask-Zurb-Foundation==0.2.1
 gunicorn==19.3.0
 itsdangerous==0.24
 Jinja2==2.8

--- a/srunner.py
+++ b/srunner.py
@@ -1,10 +1,15 @@
 import os
-from flask import Flask
+from flask import Flask, render_template
+from flask_zurb_foundation import Foundation
 
 app = Flask(__name__)
+Foundation(app)
 
 @app.route('/')
 def hello():
-    return 'Hello World!'
+    return render_template('index.html')
 
 
+if __name__ == '__main__':
+    app.debug = True
+    app.run()

--- a/srunner_tests.py
+++ b/srunner_tests.py
@@ -14,7 +14,7 @@ class SrunnerTestCase(unittest.TestCase):
 
     def test_empty_db(self):
         rv = self.app.get('/')
-        assert 'Hello World!' in rv.data
+        self.assertIn('Hello world',rv.data)
 
 
 if __name__ == '__main__':

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,4 @@
+{% extends "foundation/base.html" %}
+{% block title %}
+Hola
+{% endblock title %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,1 @@
 {% extends "foundation/base.html" %}
-{% block title %}
-Hola
-{% endblock title %}

--- a/templates/includes/navigation.html
+++ b/templates/includes/navigation.html
@@ -1,0 +1,3 @@
+<ul>
+  <li>Navigation</li>
+</ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+{% include 'includes/navigation.html' %}
+    <h6> Hello world </h6>
+{% endblock content %}


### PR DESCRIPTION
**What**

Added initial support for Zurb 5.1 and created base template with
support for include navigation and index page.

**How to test**
1. Activate your local virtualenv for the survey runner project.
2. Checkout this branch
3. Run either `python app.py` or `heroku local` to run the application in a web server
4. Visit the resultant url 
5. View the source to check for foundation static elements.

**Who can test**

Anyone but @dhilton
