### PR TITLE
Add dynamic forms json schema to survey runner application

### DIFF
--- a/jsonforms.py
+++ b/jsonforms.py
@@ -1,7 +1,53 @@
-import wtforms
+from wtforms import fields as f
+from wtforms import Form
+from wtforms import validators
+import re
+import json
+from unidecode import unidecode
+
+_punct_re = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
+
+
+def slugify(text, delim=u'-'):
+    """Generates an ASCII-only slug."""
+    result = []
+    for word in _punct_re.split(text.lower()):
+        result.extend(unidecode(word).split())
+    return unicode(delim.join(result))
+
+class Converter(object):
+    """docstring for Converter"""
+
+    def convert(self, question):
+        """Given a question dict structure, return a TextField"""
+        kwargs = {
+            'label': question['title'],
+            'description': question['help_text'],
+            'validators': [],
+            'filters': [],
+        }
+        return  f.StringField( **kwargs)
+
+
+def json_fields(form_schema):
+    """
+    Given a form schema in json, return a dictionary of fields,
+    having called the converter on each field.
+    """
+    converter = Converter()
+    field_dict = {}
+    for question in form_schema['questions']:
+        field = converter.convert(question)
+        if field is not None:
+            field_dict[question['title']] = field
+
+    return field_dict
+
 
 def convert_to_wtform(form_schema):
     """
     Given a form schema object, convert that to a valid wtforms form object.
     """
-    pass
+    f_schema = json.loads(form_schema)
+    field_dict = json_fields(f_schema)
+    return type(str(slugify(f_schema['questionnaire_title'])) + 'Form', (Form, ), field_dict)

--- a/jsonforms.py
+++ b/jsonforms.py
@@ -1,0 +1,7 @@
+import wtforms
+
+def convert_to_wtform(form_schema):
+    """
+    Given a form schema object, convert that to a valid wtforms form object.
+    """
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,12 @@
 Flask==0.10.1
+Flask-WTF==0.12
 Flask-Zurb-Foundation==0.2.1
 gunicorn==19.3.0
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23
+pep8ify==0.0.13
+requests==2.7.0
 Werkzeug==0.10.4
 wheel==0.24.0
+WTForms==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Jinja2==2.8
 MarkupSafe==0.23
 pep8ify==0.0.13
 requests==2.7.0
+Unidecode==0.4.18
 Werkzeug==0.10.4
 wheel==0.24.0
 WTForms==2.0.2

--- a/srunner.py
+++ b/srunner.py
@@ -1,17 +1,21 @@
 import os
-from flask import Flask, render_template, redirect
+from flask import Flask, render_template, redirect, request
 from flask_zurb_foundation import Foundation
 from flask_wtf import Form
 from wtforms import StringField, TextField
 from wtforms.validators import DataRequired
 import requests
+import os
+from jsonforms import convert_to_wtform
+import logging
 
+logging.basicConfig(level=logging.WARN)
 
 app = Flask(__name__)
 Foundation(app)
 # @TODO change this env variable
 app.secret_key = 'A0Zr98j/3yX R~XHH!jmN]LWX/,?RT'
-
+app.survey_registry_url = os.environ.get('SURVEY_REGISTRY_URL', None)
 
 @app.route('/')
 def hello():
@@ -20,12 +24,18 @@ def hello():
 
 @app.route('/questionnaire/<int:questionnaire_id>', methods=('GET', 'POST'))
 def questionnaire_viewer(questionnaire_id):
-    if request.method == 'POST':
-        pass
-    qurl = app.survey_registry_url + '/questionnaire/' + questionnaire_id
+    preview=False
+    if request.args.get('preview'):
+        preview=True
+
+    qurl = 'http://'+app.survey_registry_url + '/surveys/api/questionnaire/' + str(questionnaire_id) + '/'
     form_schema = requests.get(qurl)
-    form = convert_to_wtform(form_schema)
-    return render_template("form.html", form=form)
+    form = convert_to_wtform(form_schema.content)
+    f_form = form(request.form)
+    if request.method == 'POST' and f_form.validate():
+        return render_template("thanks.html", data=f_form.data)
+    return render_template("form.html", form=f_form, preview=preview)
+
 
 
 if __name__ == '__main__':

--- a/srunner.py
+++ b/srunner.py
@@ -28,7 +28,7 @@ def questionnaire_viewer(questionnaire_id):
     if request.args.get('preview'):
         preview=True
 
-    qurl = 'http://'+app.survey_registry_url + '/surveys/api/questionnaire/' + str(questionnaire_id) + '/'
+    qurl = app.survey_registry_url + '/surveys/api/questionnaire/' + str(questionnaire_id) + '/'
     form_schema = requests.get(qurl)
     form = convert_to_wtform(form_schema.content)
     f_form = form(request.form)

--- a/srunner.py
+++ b/srunner.py
@@ -1,13 +1,31 @@
 import os
-from flask import Flask, render_template
+from flask import Flask, render_template, redirect
 from flask_zurb_foundation import Foundation
+from flask_wtf import Form
+from wtforms import StringField, TextField
+from wtforms.validators import DataRequired
+import requests
+
 
 app = Flask(__name__)
 Foundation(app)
+# @TODO change this env variable
+app.secret_key = 'A0Zr98j/3yX R~XHH!jmN]LWX/,?RT'
+
 
 @app.route('/')
 def hello():
     return render_template('index.html')
+
+
+@app.route('/questionnaire/<int:questionnaire_id>', methods=('GET', 'POST'))
+def questionnaire_viewer(questionnaire_id):
+    if request.method == 'POST':
+        pass
+    qurl = app.survey_registry_url + '/questionnaire/' + questionnaire_id
+    form_schema = requests.get(qurl)
+    form = convert_to_wtform(form_schema)
+    return render_template("form.html", form=form)
 
 
 if __name__ == '__main__':

--- a/srunner_tests.py
+++ b/srunner_tests.py
@@ -21,8 +21,7 @@ class SrunnerTestCase(unittest.TestCase):
 
     def test_questionnaire_render(self):
         FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"help_text": "All sizes count, even grandfathers.", "error_text": "Sorry - that doesn\'t look like a valid entry.", "title": "How many marbles do you have?"}]}'
-        f_schema = json.loads(FORM_SCHEMA)
-        test_form = convert_to_wtform(f_schema)
+        test_form = convert_to_wtform(FORM_SCHEMA)
         self.assertEqual(type(test_form) is  wtforms.form.FormMeta, True)
 
 if __name__ == '__main__':

--- a/srunner_tests.py
+++ b/srunner_tests.py
@@ -14,9 +14,7 @@ class SrunnerTestCase(unittest.TestCase):
 
     def test_empty_db(self):
         rv = self.app.get('/')
-        self.assertIn('Hello world',rv.data)
-
-
+        assert 'Hello world!' in rv.data
 
 if __name__ == '__main__':
     unittest.main()

--- a/srunner_tests.py
+++ b/srunner_tests.py
@@ -2,6 +2,9 @@ import os
 import srunner
 import unittest
 import tempfile
+from jsonforms import convert_to_wtform
+import json
+import wtforms
 
 class SrunnerTestCase(unittest.TestCase):
 
@@ -15,6 +18,12 @@ class SrunnerTestCase(unittest.TestCase):
     def test_empty_db(self):
         rv = self.app.get('/')
         assert 'Hello world!' in rv.data
+
+    def test_questionnaire_render(self):
+        FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"help_text": "All sizes count, even grandfathers.", "error_text": "Sorry - that doesn\'t look like a valid entry.", "title": "How many marbles do you have?"}]}'
+        f_schema = json.loads(FORM_SCHEMA)
+        test_form = convert_to_wtform(f_schema)
+        self.assertEqual(type(test_form) is  wtforms.form.FormMeta, True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,8 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
 {% from "includes/_formhelpers.html" import render_field %}
- <form method="POST" action="/submit">
-   {{ form.hidden_tag() }}
+{% if preview == true %}
+  <div class="preview">
+      <h3>This is a preview - no data will be submitted downstream.</h3>
+  </div>
+{% endif %}
+
+ <form method="POST" action="">
    {% for field in form if field.widget.input_type != 'hidden' %}
      {{ field.label }}
      {{ field }}

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+{% from "includes/_formhelpers.html" import render_field %}
+ <form method="POST" action="/submit">
+   {{ form.hidden_tag() }}
+   {% for field in form if field.widget.input_type != 'hidden' %}
+     {{ field.label }}
+     {{ field }}
+   {% endfor %}
+       <input type="submit" value="Submit">
+</form>
+
+{% endblock content %}

--- a/templates/includes/_formhelpers.html
+++ b/templates/includes/_formhelpers.html
@@ -1,0 +1,12 @@
+{% macro render_field(field) %}
+  <dt>{{ field.label }}
+  <dd>{{ field(**kwargs)|safe }}
+  {% if field.errors %}
+    <ul class=errors>
+    {% for error in field.errors %}
+      <li>{{ error }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+  </dd>
+{% endmacro %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 {% block content %}
 {% include 'includes/navigation.html' %}
-    <h6> Hello world </h6>
+    <h6> Hello world! </h6>
 {% endblock content %}

--- a/templates/thanks.html
+++ b/templates/thanks.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<h2> Thanks for completing the survey.</h2>
+
+<p>Your recipt number is: <strong>45563786-2</strong></p>
+
+{% endblock content %}

--- a/templates/thanks.html
+++ b/templates/thanks.html
@@ -3,5 +3,12 @@
 <h2> Thanks for completing the survey.</h2>
 
 <p>Your recipt number is: <strong>45563786-2</strong></p>
+<dl>
+{% for key, value in data.iteritems() %}
+    <dt>{{ key|e }}</dt>
+    <dd>{{ value|e }}</dd>
+{% endfor %}
+</dl>
+
 
 {% endblock content %}


### PR DESCRIPTION
**What**

This pull request enables the survey runner to consume and render a form dynamically based off of a survey authored in the author tool. 

**How to test**
1. Check that the tests run correctly
2. Checkout the eq-terraform branch: https://github.com/ONSdigital/eq-terraform/tree/digeq-6-preview-questionnaire
3. Edit the file `deploy_surveyrunner.sh` to set the branch to: `add-dyanmic-forms-json-schema`
4. Edit the file `deploy_author.sh` to set the branch to: `digeq-6-preview-a-questionnaire`
5. Run `terraform apply --var 'env=MYENV'`
6. Visit the resulting urls and create a new survey and questionnaire with questions. 
7. Click the preview link to view a preview of the questionnaire.

**Who**

Anyone but @LJBabbage or @dhilton 
