### PR TITLE
Digeq 10 respondent completes questionnaire

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn srunner:app --log-file=-
+web: gunicorn srunner:app --log-file -

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,16 @@
 Flask==0.10.1
 Flask-WTF==0.12
 Flask-Zurb-Foundation==0.2.1
+funcsigs==0.4
 gunicorn==19.3.0
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23
+mock==1.3.0
+pbr==1.8.0
 pep8ify==0.0.13
 requests==2.7.0
+six==1.9.0
 Unidecode==0.4.18
 Werkzeug==0.10.4
 wheel==0.24.0

--- a/srunner.py
+++ b/srunner.py
@@ -6,10 +6,10 @@ from wtforms import StringField, TextField
 from wtforms.validators import DataRequired
 import requests
 import os
+import json
 from jsonforms import convert_to_wtform
-import logging
+import random
 
-logging.basicConfig(level=logging.WARN)
 
 app = Flask(__name__)
 Foundation(app)
@@ -33,8 +33,15 @@ def questionnaire_viewer(questionnaire_id):
     form = convert_to_wtform(form_schema.content)
     f_form = form(request.form)
     if request.method == 'POST' and f_form.validate():
-        return render_template("thanks.html", data=f_form.data)
-    return render_template("form.html", form=f_form, preview=preview)
+        receipt_id = random.randrange(10000, 100000)
+        app.logger.warning('{"rid": %d, "data": %s} ', receipt_id, json.dumps(f_form.data))
+        return render_template("thanks.html",
+                                data=f_form.data,
+                                receipt_id=receipt_id)
+
+    return render_template("form.html",
+                            form=f_form,
+                            preview=preview)
 
 
 

--- a/srunner.py
+++ b/srunner.py
@@ -22,15 +22,19 @@ def hello():
     return render_template('index.html')
 
 
+def get_form_schema(questionnaire_id):
+    qurl = app.survey_registry_url + '/surveys/api/questionnaire/' + str(questionnaire_id) + '/'
+    form_schema = requests.get(qurl)
+    return form_schema.content
+
+
 @app.route('/questionnaire/<int:questionnaire_id>', methods=('GET', 'POST'))
 def questionnaire_viewer(questionnaire_id):
     preview=False
     if request.args.get('preview'):
         preview=True
 
-    qurl = app.survey_registry_url + '/surveys/api/questionnaire/' + str(questionnaire_id) + '/'
-    form_schema = requests.get(qurl)
-    form = convert_to_wtform(form_schema.content)
+    form = convert_to_wtform(get_form_schema(questionnaire_id))
     f_form = form(request.form)
     if request.method == 'POST' and f_form.validate():
         receipt_id = random.randrange(10000, 100000)

--- a/srunner.py
+++ b/srunner.py
@@ -9,10 +9,18 @@ import os
 import json
 from jsonforms import convert_to_wtform
 import random
-
+import logging
+from logging import StreamHandler
 
 app = Flask(__name__)
 Foundation(app)
+
+# log to stderr
+
+file_handler = StreamHandler()
+app.logger.setLevel(logging.DEBUG)  # set the desired logging level here
+app.logger.addHandler(file_handler)
+
 # @TODO change this env variable
 app.secret_key = 'A0Zr98j/3yX R~XHH!jmN]LWX/,?RT'
 app.survey_registry_url = os.environ.get('SURVEY_REGISTRY_URL', None)

--- a/srunner_tests.py
+++ b/srunner_tests.py
@@ -72,12 +72,12 @@ class SrunnerLoggingTest(unittest.TestCase):
         # check that given a submission we log
         # the correct data.
         self.app.logger.warning('{"rid": , "data": {"what is your hair colour?": "blue"}} ')
-        self.assertEqual(len(self.app.logger.handlers[1].messages['warning']), 1)
+        self.assertEqual(len(self.app.logger.handlers[2].messages['warning']), 1)
         self.client = srunner.app.test_client()
         response = self.client.post("/questionnaire/1",  data={
                                                         'How many marbles do you have?':'4'
                                 }, follow_redirects=True)
-        self.assertEqual(len(self.app.logger.handlers[1].messages['warning']), 2)
+        self.assertEqual(len(self.app.logger.handlers[2].messages['warning']), 2)
 
     def tearDown(self):
         self.mock_get_form_schema.stop()

--- a/srunner_tests.py
+++ b/srunner_tests.py
@@ -5,6 +5,37 @@ import tempfile
 from jsonforms import convert_to_wtform
 import json
 import wtforms
+import logging
+from mock import patch
+
+class MockLoggingHandler(logging.Handler):
+    """Mock logging handler to check for expected logs.
+
+    Messages are available from an instance's ``messages`` dict, in order, indexed by
+    a lowercase log level string (e.g., 'debug', 'info', etc.).
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.messages = {'debug': [], 'info': [], 'warning': [], 'error': [],
+                         'critical': []}
+        super(MockLoggingHandler, self).__init__(*args, **kwargs)
+
+    def emit(self, record):
+        "Store a message from ``record`` in the instance's ``messages`` dict."
+        self.acquire()
+        try:
+            self.messages[record.levelname.lower()].append(record.getMessage())
+        finally:
+            self.release()
+
+    def reset(self):
+        self.acquire()
+        try:
+            for message_list in self.messages.values():
+                message_list.clear()
+        finally:
+            self.release()
+
 
 class SrunnerTestCase(unittest.TestCase):
 
@@ -23,6 +54,33 @@ class SrunnerTestCase(unittest.TestCase):
         FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"help_text": "All sizes count, even grandfathers.", "error_text": "Sorry - that doesn\'t look like a valid entry.", "title": "How many marbles do you have?"}]}'
         test_form = convert_to_wtform(FORM_SCHEMA)
         self.assertEqual(type(test_form) is  wtforms.form.FormMeta, True)
+
+
+class SrunnerLoggingTest(unittest.TestCase):
+
+    def setUp(self):
+        self.FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"help_text": "All sizes count, even grandfathers.", "error_text": "Sorry - that doesn\'t look like a valid entry.", "title": "How many marbles do you have?"}]}'
+        srunner.app.config['TESTING'] = True
+        self.app = srunner.app
+        self.patcher = patch('srunner.get_form_schema')
+        self.mock_get_form_schema = self.patcher.start()
+        self.mock_get_form_schema.return_value = self.FORM_SCHEMA
+        self.app.logger.addHandler(MockLoggingHandler())
+
+    def test_data_logs_correctly(self):
+        # Need to generate a questionnaire and then
+        # check that given a submission we log
+        # the correct data.
+        self.app.logger.warning('{"rid": , "data": {"what is your hair colour?": "blue"}} ')
+        self.assertEqual(len(self.app.logger.handlers[1].messages['warning']), 1)
+        self.client = srunner.app.test_client()
+        response = self.client.post("/questionnaire/1",  data={
+                                                        'How many marbles do you have?':'4'
+                                }, follow_redirects=True)
+        self.assertEqual(len(self.app.logger.handlers[1].messages['warning']), 2)
+
+    def tearDown(self):
+        self.mock_get_form_schema.stop()
 
 if __name__ == '__main__':
     unittest.main()

--- a/templates/thanks.html
+++ b/templates/thanks.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2> Thanks for completing the survey.</h2>
 
-<p>Your recipt number is: <strong>45563786-2</strong></p>
+<p>Your recipt number is: <strong>{{receipt_id}}</strong></p>
 <dl>
 {% for key, value in data.iteritems() %}
     <dt>{{ key|e }}</dt>


### PR DESCRIPTION
**What**

This PR enables the logging of a result from a questionnaire being filled out to a std logger.
In practise for now this dumps the results as JSON to a logger. 

**How to test**
1. Using eq-terraform, alter the `deploy_surveyrunner.sh` script to deploy this branch: `digeq-10-respondent-completes-questionnaire`
2. Deploy a new environment using eq-terraform 
3. Create a new survey, questionnaire and at least one question. 
4. Complete a preview survey - this will generate a log entry.
5. Within your eq-terraform directory, cd into ./tmp/eq-surveyrunner/
6. Run `Heroku logs`
7. You should see a log entry for your questionnaire entry.

**Who can test**

Anyone but @warren-methods or @dhilton
