### PR TITLE
Added new rendering of fields and added correct field description text

### DIFF
--- a/jsonforms.py
+++ b/jsonforms.py
@@ -22,7 +22,7 @@ class Converter(object):
         """Given a question dict structure, return a TextField"""
         kwargs = {
             'label': question['title'],
-            'description': question['help_text'],
+            'description': question['description'],
             'validators': [],
             'filters': [],
         }

--- a/srunner_tests.py
+++ b/srunner_tests.py
@@ -51,7 +51,7 @@ class SrunnerTestCase(unittest.TestCase):
         assert 'Hello world!' in rv.data
 
     def test_questionnaire_render(self):
-        FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"help_text": "All sizes count, even grandfathers.", "error_text": "Sorry - that doesn\'t look like a valid entry.", "title": "How many marbles do you have?"}]}'
+        FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"description": "All sizes count, even grandfathers.", "error_text": "Sorry - that doesn\'t look like a valid entry.", "title": "How many marbles do you have?"}]}'
         test_form = convert_to_wtform(FORM_SCHEMA)
         self.assertEqual(type(test_form) is  wtforms.form.FormMeta, True)
 
@@ -59,7 +59,7 @@ class SrunnerTestCase(unittest.TestCase):
 class SrunnerLoggingTest(unittest.TestCase):
 
     def setUp(self):
-        self.FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"help_text": "All sizes count, even grandfathers.", "error_text": "Sorry - that doesn\'t look like a valid entry.", "title": "How many marbles do you have?"}]}'
+        self.FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"description": "All sizes count, even grandfathers.", "error_text": "Sorry - that doesn\'t look like a valid entry.", "title": "How many marbles do you have?"}]}'
         srunner.app.config['TESTING'] = True
         self.app = srunner.app
         self.patcher = patch('srunner.get_form_schema')

--- a/templates/survey_index.html
+++ b/templates/survey_index.html
@@ -30,7 +30,7 @@
     <a class="skiplink visuallyhidden focusable" href="#main" tabindex="0">
       <span>Skip to main content</span>
     </a>
-	
+
 	<header class="desktop-full-width">
 	      <div class="notice"><em>Notice is given under section 1 of the Statistics of Trade Act 1947</em></div>
 	      <div class="wrapper">
@@ -40,7 +40,7 @@
 	          </div>
 	          <div class="grid-wrap survey-heading">
 	            <div class="desktop-grid-full-width">
-	              <h1 class="beta">{{ questionnaire.questionnaire_title }}</h1>
+	              <h1 class="beta">{{ questionnaire.title }}</h1>
 	              <p>NB: Your response is legally required</p>
 	              <aside><p>Your REF : XYZ76545</p><p>Helpline 0800 0858163</p></aside>
 	            </div>
@@ -60,9 +60,9 @@
       <div class="grid-col mobile-grid-full-width  desktop-grid-full-width">
 
      <!--<p>{{ questionnaire.overview }}</p>-->
-	 
+
      <p>Dear Sir or Madam,</p>
-     <p>Please find below the July 2015 questionnaire for the Monthly Vacancy Survey. Your data should cover the period
+     <p>Please find below the July 2015 questionnaire for the {{ questionnaire.title }}. Your data should cover the period
      3 July 2015. If actual figures are not available, please provide informed estimates.</p>
      <p>The information supplied is used to produce a comprehensive and reliable measure of job vacancies across the economy.
      Results are published in the monthly Labour Market Statistical Bulletin and used by the Treasury and the Bank of England as a valuable indicator of labour demand.
@@ -87,7 +87,7 @@
 {% for field in form if field.widget.input_type != 'hidden' %}
 <label class="field field--spaced field--text">
   <b class="field__label">  {{ field.label }}</b>
-  <span class="description field__description label__description"></span>
+  <span class="description field__description label__description">{{ field.description }}</span>
       {{ field }}
 </label>
 {% endfor %}


### PR DESCRIPTION
**What**

This PR alters the rendering of a Survey to a respondent to include the description text and the correct survey title and opposed to the questionnaire title.

**How to test**
1. In a locally cloned version of eq-terraform, edit `deploy_surveyrunner.sh` to deploy this branch: `sprint1-fix-survey-display`
2. Use eq-terraform to create a new environment.
3. Create a new questionnaire, add questions and preview this survey.

**who can test**

Anyone but @dhilton 
