### PR TITLE
DIG-59 choice field is rendering incorrectly 

### DIFF
--- a/jsonforms.py
+++ b/jsonforms.py
@@ -46,7 +46,7 @@ class Converter(object):
         self.field = f.StringField(**kwargs)
 
     def convert_radiofield(self, question):
-        """Given a question dict structure, return a TextField"""
+        """Given a multipe choice question dict structure, return a Radio Field"""
         kwargs = {
             '_name': slugify(question['questionText']),
             'label': question['questionText'],
@@ -61,8 +61,8 @@ class Converter(object):
         choices = []
         for part in parts:
             value = part['value']
-            name = part['name']
-            choice = (name, value)
+            description = part['name']
+            choice = (value, description)
             choices.append(choice)
         return choices
 


### PR DESCRIPTION
**What**
The survey runner was rendering the multiple choice questions incorrectly, the value was being displayed and the name was being submitted. This was due to the wtforms expecting the choice fields to have value first, description second.

**How to test**
1] `docker-compose up`
2] http://127.0.0.1:8080/questionnaire/1/ABCD?debug=True

**Who can review**
Anyone apart from @warren-methods
