### PR TITLE
DIGEQ-56 Respondent view rich text form field

### DIFF
--- a/jsonforms.py
+++ b/jsonforms.py
@@ -4,6 +4,10 @@ from wtforms import validators
 import re
 import json
 from unidecode import unidecode
+from widgets import RichTextDisplayWidget
+import bleach
+from bleach_whitelist import print_tags, print_attrs, all_styles
+
 
 _punct_re = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
 
@@ -22,13 +26,14 @@ class Converter(object):
     field = {}
 
     def __init__(self, question):
-        print question
         questiontype = question['questionType']
 
         if questiontype == "InputText":
             self.convert_textfield(question)
         elif questiontype == "MultipleChoice":
             self.convert_radiofield(question)
+        elif questiontype == "TextBlock":
+            self.convert_textblock(question)
         return
 
     def get_field(self):
@@ -66,6 +71,18 @@ class Converter(object):
             choices.append(choice)
         return choices
 
+    def convert_textblock(self, question):
+        """Given a question dict structure, return a TextBlock"""
+        kwargs = {
+            '_name': slugify(question['questionText']),
+            'label': '',
+            'default': bleach.clean(question['questionText'], print_tags),
+            'description': '',
+            'validators': [validators.optional()],
+            'filters': [],
+            'widget': RichTextDisplayWidget()
+        }
+        self.field = f.TextAreaField(**kwargs)
 
 
 def json_fields(form_schema):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 backports.ssl-match-hostname==3.4.0.2
+bleach==1.4.2
+bleach-whitelist==0.0.7
 cassandra-driver==2.7.2
+decorator==4.0.4
 docker-compose==1.4.2
 docker-py==1.3.1
 dockerpty==0.3.4
@@ -12,6 +15,9 @@ Flask-Zurb-Foundation==0.2.1
 funcsigs==0.4
 futures==3.0.3
 gunicorn==19.3.0
+html5lib==0.9999999
+infinity==1.3
+intervals==0.3.1
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23
@@ -21,9 +27,13 @@ pep8ify==0.0.13
 PyYAML==3.11
 requests==2.6.2
 six==1.10.0
+SQLAlchemy==1.0.8
+SQLAlchemy-Utils==0.31.0
 texttable==0.8.3
 Unidecode==0.4.18
+validators==0.9
 websocket-client==0.32.0
 Werkzeug==0.10.4
 wheel==0.24.0
 WTForms==2.0.2
+WTForms-Components==0.9.8

--- a/srunner_tests.py
+++ b/srunner_tests.py
@@ -60,6 +60,11 @@ class SrunnerTestCase(unittest.TestCase):
         test_form = convert_to_wtform(FORM_SCHEMA)
         self.assertEqual(type(test_form) is  wtforms.form.FormMeta, True)
 
+    def test_questionnaire_render_with_richtextblock(self):
+        FORM_SCHEMA = open(r"./test_fixtures/test_survey.json", "r").read()
+        test_form = convert_to_wtform(FORM_SCHEMA)
+        self.assertEqual(type(test_form) is  wtforms.form.FormMeta, True)
+
 class SrunnerLoggingTest(unittest.TestCase):
 
     def setUp(self):

--- a/test_fixtures/test_survey.json
+++ b/test_fixtures/test_survey.json
@@ -22,7 +22,7 @@
       {
      "questionType": "TextBlock",
      "questionError": "",
-     "questionText": "This is <strong>strong<\/strong>  and this is <i>Italic<\/i>",
+     "questionText": "This is <strong>strong<\/strong> <script>alert('l33t');</script>  and this is <i>Italic<\/i>",
      "displayConditions": [
 
      ],
@@ -46,7 +46,7 @@
      "skipConditions": [
 
      ]
-   }, 
+   },
       {
         "questionType": "MultipleChoice",
         "questionText": "Which colour marble would you prefer?",

--- a/widgets.py
+++ b/widgets.py
@@ -1,0 +1,15 @@
+from wtforms import Field
+from wtforms import Form
+from wtforms import validators
+from wtforms.widgets import TextArea, html_params
+from flask import Markup
+
+class RichTextDisplayWidget(TextArea):
+    html_params = staticmethod(html_params)
+
+    def __init__(self, **kwargs):
+        super(RichTextDisplayWidget, self).__init__()
+
+    def __call__(self, field, **kwargs):
+        html_temp = '<div class="rich_text_display"><p>%s</p></div>'
+        return Markup(html_temp % ( field.default))


### PR DESCRIPTION
**What**

This PR creates a RichTextField that enables an Author to create
a text box in their questionnaire to inform a respondent.

We've added a new convertor to jsonforms and created a whitelist
approach to HTML tags based on the python bleach package.

This commit also creates a folder for test fixtures so that we can
create a range of new survey examples without having to have the
strings inline in the test files.

The requirements have been updated and will require a rebuild of
our downstream docker images.

We created a custom widget for displaying a text block.

**How to test**
1. Create a new environment, a new survey and questionnaire with a RichTextBox.
2. Add some html tags to that box, including script and similar tags.
3. Save the questionnaire.
4. View in the Survey runner.
5. The expected output is that only allowed print styles (bold, italic, underline) should be allowed to be rendered and not the script example.

**Who can test**

Anyone but @dhilton or @LJBabbage 
