### PR TITLE
DIGEQ-134 Fixing cassandra issue where it was opening a connection per request …

### DIFF
--- a/srunner.py
+++ b/srunner.py
@@ -1,9 +1,5 @@
-import os
 from flask import Flask, render_template, redirect, request, session
 from flask_zurb_foundation import Foundation
-from flask_wtf import Form
-from wtforms import StringField, TextField
-from wtforms.validators import DataRequired
 import requests
 import os
 import json
@@ -52,22 +48,23 @@ def get_form_schema(questionnaire_id):
 
 
 def get_session_data(quest_session_id, session_id):
-    session = cassandra.connect()
-    session.set_keyspace("sessionstore")
+    cassandra_session = cassandra.connection
+    cassandra_session.set_keyspace("sessionstore")
     cql = "SELECT data FROM sessions WHERE  quest_session_id = '{}' LIMIT 1;".format(quest_session_id)
-    r = session.execute(cql)
+    r = cassandra_session.execute(cql)
 
     if r:
         payload = json.loads(r[0].data)
         return payload
     return None
 
+
 def set_session_data(quest_session_id, session_id, data):
-    session = cassandra.connect()
-    session.set_keyspace("sessionstore")
+    cassandra_session = cassandra.connection
+    cassandra_session.set_keyspace("sessionstore")
     cql = "INSERT into sessions (session_id, quest_session_id, data) VALUES ('{}', '{}', '{}');".format(session_id, quest_session_id, data)
     app.logger.debug(cql)
-    r = session.execute(cql)
+    r = cassandra_session.execute(cql)
     app.logger.debug(r)
     return r
 


### PR DESCRIPTION
**What**
Fixing cassandra issue where it was opening a connection per request and not closing it, causing the stack to eventually collapse when it ran out of file handles. To fix it we just need to use the connection property rather than the connect as the API in use is already managing the connection pooling

**How to test**
1] Checkout this branch
2] Run docker-compose up
3] Browse to http://127.0.0.1:8080/questionnaire/1/ABCD?debug=True 
4] Check save works

**Who can review**
Anyone apart from @warren-methods
