### PR TITLE
DIGEQ-143 Interim save - multiple choice answers only contain a single value

### DIFF
--- a/jsonforms.py
+++ b/jsonforms.py
@@ -66,7 +66,7 @@ class Converter(object):
         choices = []
         for part in parts:
             value = part['value']
-            description = part['name']
+            description = part['value']
             choice = (value, description)
             choices.append(choice)
         return choices

--- a/srunner_tests.py
+++ b/srunner_tests.py
@@ -56,7 +56,7 @@ class SrunnerTestCase(unittest.TestCase):
         self.assertEqual(type(test_form) is  wtforms.form.FormMeta, True)
 
     def test_questionnaire_render_with_multipe_choice(self):
-        FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"questionType": "MultiChoice", "questionHelp": "Only the displayed colours are available.", "questionError": "That isn\'t a valid answer", "questionText": "Which colour marble would you prefer?", "parts":[{"name": "Blue","label": "Not Red or Green","value": "Blue Marble"},{"name": "Red","label": "Not green or blue","value": "Red Marble"},{"name": "Green","label": "Not Blue or Red","value": "Green Marble"}]}]}'
+        FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"questionType": "MultiChoice", "questionHelp": "Only the displayed colours are available.", "questionError": "That isn\'t a valid answer", "questionText": "Which colour marble would you prefer?", "parts":[{"value": "Blue"},{"value": "Red"},{"value": "Green"}]}]}'
         test_form = convert_to_wtform(FORM_SCHEMA)
         self.assertEqual(type(test_form) is  wtforms.form.FormMeta, True)
 
@@ -68,7 +68,7 @@ class SrunnerTestCase(unittest.TestCase):
 class SrunnerLoggingTest(unittest.TestCase):
 
     def setUp(self):
-        self.FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"questionType": "InputText", "questionHelp": "All sizes count, even grandfathers.", "questionError": "Sorry - that doesn\'t look like a valid entry.", "questionText": "How many marbles do you have?"},{"questionType": "MultiChoice", "questionHelp": "Only the displayed colours are available.", "questionError": "That isn\'t a valid answer", "questionText": "Which colour marble would you prefer?", "parts":[{"name": "Blue","label": "Not Red or Green","value": "Blue Marble"},{"name": "Red","label": "Not green or blue","value": "Red Marble"},{"name": "Green","label": "Not Blue or Red","value": "Green Marble"}]}]}'
+        self.FORM_SCHEMA = '{"overview": "This is a questionnaire to test stuff", "questionnaire_title": "Hope", "questions": [{"questionType": "InputText", "questionHelp": "All sizes count, even grandfathers.", "questionError": "Sorry - that doesn\'t look like a valid entry.", "questionText": "How many marbles do you have?"},{"questionType": "MultiChoice", "questionHelp": "Only the displayed colours are available.", "questionError": "That isn\'t a valid answer", "questionText": "Which colour marble would you prefer?", "parts":[{"value": "Blue"},{"value": "Red"},{"value": "Green"}]}]}'
         srunner.app.config['TESTING'] = True
         self.app = srunner.app
         self.patcher = patch('srunner.get_form_schema')

--- a/templates/survey.json
+++ b/templates/survey.json
@@ -63,19 +63,13 @@
         "branchConditions": [],
         "parts": [
           {
-            "name": "Blue",
-            "label": "Not Red or Green",
-            "value": "Blue Marble"
+            "value": "Blue"
           },
           {
-            "name": "Red",
-            "label": "Not green or blue",
-            "value": "Red Marble"
+            "value": "Red"
           },
           {
-            "name": "Green",
-            "label": "Not Blue or Red",
-            "value": "Green Marble"
+            "value": "Green"
           }
         ]
       }

--- a/test_fixtures/test_survey.json
+++ b/test_fixtures/test_survey.json
@@ -63,19 +63,13 @@
         "branchConditions": [],
         "parts": [
           {
-            "name": "Blue",
-            "label": "Not Red or Green",
-            "value": "Blue Marble"
+            "value": "Blue"
           },
           {
-            "name": "Red",
-            "label": "Not green or blue",
-            "value": "Red Marble"
+            "value": "Red"
           },
           {
-            "name": "Green",
-            "label": "Not Blue or Red",
-            "value": "Green Marble"
+            "value": "Green"
           }
         ]
       }


### PR DESCRIPTION
**What**
The label and name fields for the multiple choice answers are no longer returned by the author app. The UI only allows one entry for a multiple choice answers so these fields are no longer valid. The survey runner now uses the value field for both value and description

How to test
1. Check out this branch
2. Delete old docker images for cassandra
3. `docker-compose build`
4. `docker-compose up`
5. View http://127.0.0.1:8080/questionnaire/1/ABCD?debug=True

Who can review
Anyone but @warren-methods
