### PR TITLE
digeq-146 rich text always bold, CSS using wrong font

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1728,7 +1728,7 @@ textarea {
 
 .field--text {
   display: block;
-  font-family: "open-sans-n7", "open-sans", sans-serif; }
+  font-family: "open-sans-n4", "open-sans", sans-serif; }
 
 .field__radio {
   margin-right: 16px;


### PR DESCRIPTION
**What**
Rich text is always bold in survey runner

**How to test**
1. Create a questionnaire with rich text in, but without making it bold
2. Open survey runner and make sure the rich text isn't bold

**Who can review**
Anyone but LJBabbage
