### PR TITLE
DIGEQ-162 render error page if a questionnaire has no questions

### DIFF
--- a/questionnaireManager.py
+++ b/questionnaireManager.py
@@ -56,20 +56,21 @@ class QuestionnaireManager:
         self.history = questionnaire_state['history']
 
         # validate any previous data
-        for index in range(0, self.question_index + 1):
-            question = self.questions[index]
-            if question.get_reference() in self.history.keys():
-                question.is_valid_response(self.responses)
+        if len(self.questions) != 0:
+            for index in range(0, self.question_index + 1):
+                question = self.questions[index]
+                if question.get_reference() in self.history.keys():
+                    question.is_valid_response(self.responses)
 
-        # evaluate skip conditions and skip matching questions
-        for question in self.questions:
-            if question.has_skip_conditions():
-                conditions = question.get_skip_conditions()
-                for condition in conditions:
-                    if self.condition_met(condition):
-                        question.skipping = True
+            # evaluate skip conditions and skip matching questions
+            for question in self.questions:
+                if question.has_skip_conditions():
+                    conditions = question.get_skip_conditions()
+                    for condition in conditions:
+                        if self.condition_met(condition):
+                            question.skipping = True
 
-        self.current_question = self.questions[self.question_index]
+            self.current_question = self.questions[self.question_index]
 
     def _add_question(self, question):
         self.questions.append(question)
@@ -97,7 +98,8 @@ class QuestionnaireManager:
     def start_questionnaire(self):
         self.started = True
         self.question_index = 0
-        self.current_question = self.questions[self.question_index]
+        if len(self.questions) != 0:
+            self.current_question = self.questions[self.question_index]
 
     def get_questionnaire_state(self):
         return {

--- a/srunner.py
+++ b/srunner.py
@@ -162,6 +162,8 @@ def questionnaire_viewer(questionnaire_id, quest_session_id=None):
 
         if q_manager.started:
             question = q_manager.get_current_question()
+            if not question:
+                return render_template('survey_error.html', questionnaire=q_manager, error="This survey has no questions")
 
             if q_manager.completed:
                 return render_template('survey_completed.html',
@@ -169,7 +171,8 @@ def questionnaire_viewer(questionnaire_id, quest_session_id=None):
                                         questionnaire=q_manager,
                                         request=request)
 
-            return render_template('questions/' + question.type + '.html',
+            else:
+                return render_template('questions/' + question.type + '.html',
                                     question=question,
                                     user_response=q_manager.get_responses(),
                                     questionnaire=q_manager,

--- a/templates/survey_error.html
+++ b/templates/survey_error.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block pageBody %}
+
+<p>{{error}}</p>
+
+{% endblock pageBody %}
+
+{% block actions %}
+
+{% endblock actions %}


### PR DESCRIPTION
**What**
Fix for DIGEQ-162. This change stops an internal server error being displayed if a questionnaire with no questions/sections is previewed or 'view lived'. Instead we render an error page informing the user that the questionnaire has no questions.

**How to test**
1. Create a questionnaire with no questions
2. Preview that questionnaire
3. Check the error page is rendered 

**Who can test**
Anyone apart from @warren-methods
