### PR TITLE
Adding new drop down question type to the star wars example

### DIFF
--- a/test_fixtures/starwars.json
+++ b/test_fixtures/starwars.json
@@ -160,6 +160,45 @@
                     "validation": {
                         "required": true
                     }
+                },
+                {
+                    "questionType": "Dropdown",
+                    "questionError": "Just one answer",
+                    "questionText": "Which Droid would purchase?",
+                    "displayConditions": [],
+                    "questionReference": "q5",
+                    "children": [],
+                    "parts": [
+                        {
+                            "type": "option",
+                            "value": "BB8"
+                        },
+                        {
+                            "type": "option",
+                            "value": "R2D2"
+                        },
+                        {
+                            "type": "option",
+                            "value": "C3P0"
+                        },
+                        {
+                            "type": "option",
+                            "value": "IG-88"
+                        },
+                        {
+                            "type": "option",
+                            "value": "2-1B"
+                        }
+                    ],
+                    "dndType": "item",
+                    "branchConditions": [],
+                    "displayProperties": {},
+                    "questionHelp": "Only select one",
+                    "validation": {
+                        "required": true
+                    },
+                    "type": "dropdown_question",
+                    "skipConditions": []
                 }
             ],
             "id": 0,


### PR DESCRIPTION
**What**
Adding new question type to the star wars example.

**How to test**
Simply view the debug survey: http://127.0.0.1:5000/questionnaire/1?debug=True

**Who can review**
Anyone apart from @warren-methods
