### PR TITLE
DIGEQ-166 Fixing issue when a multiple choice question does not have a routing rule

### DIFF
--- a/questionnaireManagerTest.py
+++ b/questionnaireManagerTest.py
@@ -374,6 +374,15 @@ class QuestionnaireManagerTest(unittest.TestCase):
 
         assert len(sectionThree.skip_conditions) == 0
 
+    def test_empty_routing_rule(self):
+        q_data = self._loadFixture('empty-rule-schema.json')
+
+        q_manager = QuestionnaireManager(q_data, {});
+        q_manager.start_questionnaire()
+
+        question = q_manager.get_current_question()
+
+        assert not question.has_branch_conditions()
 
 if __name__ == '__main__':
     unittest.main()

--- a/questions.py
+++ b/questions.py
@@ -51,7 +51,7 @@ class Question(object):
     def _build_branch_conditions(self, branch_conditions_schema):
         branch_conditions = []
         for condition in branch_conditions_schema:
-             if condition['jumpTo']:
+             if condition['jumpTo'] and condition['jumpTo']['condition']['value']['is']:
                 jumpTo = JumpTo(condition['jumpTo']['question'], self.get_reference(), condition['jumpTo']['condition']['value']['is'])
                 branch_conditions.append(jumpTo)
 

--- a/test_fixtures/empty-rule-schema.json
+++ b/test_fixtures/empty-rule-schema.json
@@ -1,0 +1,64 @@
+{
+    "overview": "This is a questionnaire to test stuff",
+    "title": "welcome to my survey about crayons",
+    "questionnaire_title": "Hope",
+    "questions": [
+        {
+            "questionText": "Section1",
+            "questionHelp": "",
+            "questionError": "",
+            "questionReference": "start",
+            "questionType": "QuestionGroup",
+            "dndType": "group",
+            "type": "group",
+            "children": [
+                {
+                    "questionText": "Multi 1",
+                    "questionHelp": "Multi 1",
+                    "questionError": "Multi 1",
+                    "questionReference": "q3",
+                    "children": [],
+                    "validation": {
+                        "required": true
+                    },
+                    "displayProperties": {},
+                    "displayConditions": [],
+                    "skipConditions": [],
+                    "branchConditions": [
+                        {
+                            "jumpTo": {
+                                "question": "",
+                                "condition": {
+                                    "value": {
+                                        "is": ""
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "parts": [
+                        {
+                            "type": "option",
+                            "value": "option1"
+                        },
+                        {
+                            "type": "option",
+                            "value": "option2"
+                        }
+                    ],
+                    "dndType": "item",
+                    "questionType": "MultipleChoice",
+                    "type": "radio_question"
+                }
+            ],
+            "validation": {
+                "required": true
+            },
+            "displayProperties": {},
+            "displayConditions": [],
+            "skipConditions": [],
+            "branchConditions": [],
+            "parts": []
+        }
+    ]
+}


### PR DESCRIPTION
**What**
If a multiple choice question does not have a routing rule then the runner wouldn't be able to display the survey. This change checks for an empty rule in the schema, if found it doesn't add the routing rule.

**How to test**
1. Create a questionnaire with a multiple choice question without a routing rule
2. Check that the survey runner can display the survey.

_Who can review_*
Anyone apart from @warren-methods.
