### PR TITLE
Maintain order in the history of previously visited sections

### DIFF
--- a/questionnaireManager.py
+++ b/questionnaireManager.py
@@ -116,17 +116,18 @@ class QuestionnaireManager:
         self._store_in_history(response)
 
     def _store_in_history(self, response):
-        if not self._exists_in_history(self.current_question.get_reference()):
-            history = {}
-            self.history.append(history)
-        else:
-            history = self._find_history(self.current_question.get_reference())
-        history['reference'] = self.current_question.get_reference()
-        history['valid'] = self.current_question.is_valid_response(response)
+        if self.current_question:
+            if not self._exists_in_history(self.current_question.get_reference()):
+                history = {}
+                self.history.append(history)
+            else:
+                history = self._find_history(self.current_question.get_reference())
+            history['reference'] = self.current_question.get_reference()
+            history['valid'] = self.current_question.is_valid_response(response)
 
     def _exists_in_history(self, reference):
         for history in self.history:
-            if history['reference'] == qreference:
+            if history['reference'] == reference:
                 return True
         return False
 

--- a/questionnaireManager.py
+++ b/questionnaireManager.py
@@ -1,6 +1,7 @@
 from questions import Question
 import json
 from branching import SkipCondition
+from collections import OrderedDict
 
 class QuestionnaireManager:
     def __init__(self, questionnaire_schema, questionnaire_state):
@@ -10,7 +11,7 @@ class QuestionnaireManager:
         self.completed = False
         self.questions = []
         self.responses = {}
-        self.history = {}
+        self.history = []
         self.current_question = None
         self._load_questionnaire_data(json.loads(questionnaire_schema))
         self._ensure_valid_routing()
@@ -47,7 +48,6 @@ class QuestionnaireManager:
                         if candidate_question.get_reference() != target_question.get_reference():
                             candidate_question.skip_conditions.append(target_questions[target_question])
 
-
     def _load_questionnaire_state(self, questionnaire_state):
         self.started = questionnaire_state['started']
         self.completed = questionnaire_state['completed']
@@ -59,7 +59,7 @@ class QuestionnaireManager:
         if len(self.questions) != 0:
             for index in range(0, self.question_index + 1):
                 question = self.questions[index]
-                if question.get_reference() in self.history.keys():
+                if self._exists_in_history(question.get_reference()):
                     question.is_valid_response(self.responses)
 
             # evaluate skip conditions and skip matching questions
@@ -113,9 +113,28 @@ class QuestionnaireManager:
     def store_response(self, response):
         for ref in response.keys():
             self.responses[ref] = response[ref]
+        self._store_in_history(response)
 
-        self.history[self.current_question.get_reference()] = self.current_question.is_valid_response(response)
+    def _store_in_history(self, response):
+        if not self._exists_in_history(self.current_question.get_reference()):
+            history = {}
+            self.history.append(history)
+        else:
+            history = self._find_history(self.current_question.get_reference())
+        history['reference'] = self.current_question.get_reference()
+        history['valid'] = self.current_question.is_valid_response(response)
 
+    def _exists_in_history(self, reference):
+        for history in self.history:
+            if history['reference'] == qreference:
+                return True
+        return False
+
+    def _find_history(self, reference):
+        for history in self.history:
+            if history['reference'] == reference:
+                return history
+        return None
 
     def is_valid_response(self, user_answer):
         if self.current_question:
@@ -173,7 +192,6 @@ class QuestionnaireManager:
                         self.current_question = self.questions[self.question_index]
                     index += 1
 
-
     def branch_to_question(self, questionnaire_location):
         index = 0
         for question in self.questions:
@@ -202,15 +220,14 @@ class QuestionnaireManager:
 
     def get_history(self):
         # load the question objects
-        history_with_question_objects = {}
-        for reference in self.history.keys():
-            question = self.get_question_by_reference(reference)
+        history_with_question_objects = OrderedDict()
+        for history in self.history:
+            question = self.get_question_by_reference(history['reference'])
 
             if not question.skipping:
-                history_with_question_objects[question] = self.history[reference]
+                history_with_question_objects[question] = history['valid']
 
         return history_with_question_objects
-
 
     def condition_met(self, condition):
        return condition.state == self.get_response_by_reference(condition.trigger)

--- a/questionnaireManagerTest.py
+++ b/questionnaireManagerTest.py
@@ -384,5 +384,34 @@ class QuestionnaireManagerTest(unittest.TestCase):
 
         assert not question.has_branch_conditions()
 
+    def test_history_order_correct(self):
+        q_data = self._loadFixture('groups.json')
+
+        q_manager = QuestionnaireManager(q_data, {})
+        q_manager.start_questionnaire()
+
+        q1 = q_manager.get_current_question()
+
+        response = {
+                'start:q1': '1',          # Numeric required field
+                'start:q2': None,         # Rich text text, no response required
+                'start:q3': 'option1',    # Multi-choice, option 1
+                'start:q4': 'option1',   # Checkbox, selected
+                'start:q5': 'Some Text',  # required free text field
+                'start:q6': None          # Optional numeric
+            }
+
+        q_manager.store_response(response)
+
+        assert q1 == q_manager.get_history().keys()[0]
+
+        q2 = q_manager.get_next_question(response)
+
+        response['q1:q2'] = 'anything you like'
+
+        q_manager.store_response(response)
+
+        assert q2 == q_manager.get_history().keys()[1]
+
 if __name__ == '__main__':
     unittest.main()

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
               {% if current == "question" and questionnaire.get_history() %}
               <div class="large-3 columns survey-nav">
                 <h6>Questionnaire Sections <!--Section {{questionnaire.get_current_question_index()}} of {{questionnaire.get_total_questions()}} - {{questionnaire.get_current_question().question_text}}--></h6>
-                <em>Required to complete survey</em>
+                <em>Visited sections</em>
                 {% if questionnaire.get_history() %}
                     <ul class="section-list">
                         {% for question in questionnaire.get_history().keys() %}


### PR DESCRIPTION
**What**
The stored history of visited section was a dict, so when displayed to the user it appear in a random order. This is because a standard dict doesn't maintain order. I tried using an OrderedDict but because the history is written to and retrieved from disk along on each request, the order is still lost. Therefore this change converts the stored history to a list of dicts so it can be stored to cassandra whilst maintaining the order it's been view in. It then uses an ordered dict when being displayed to the user. This should stop the random order that is currently happening.

**How to test**
1. Start the survey runner
2. Browse to the debug survey. 
3. Visit multiple sections and check the order is maintained.
