### PR TITLE
Downgrade python to 2.7.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.10
+FROM python:2.7.9
 
 RUN mkdir /opt/eq-survey-runner
 add ./requirements.txt /opt/eq-survey-runner/requirements.txt


### PR DESCRIPTION
**What**
The 2.7.10 docker image of python has an issue, going to version 2.7.9 temporarily to solve it.  

**How to test**
Checkout this branch and run `docker build .`

**Who can review**
Anyone apart from @warren-methods
