### PR TITLE
Fixing mandatory dropdown

### DIFF
--- a/templates/questions/Dropdown.html
+++ b/templates/questions/Dropdown.html
@@ -4,7 +4,7 @@
 <h3><span>{{ question.question_text }}</span></h3>
 <p>{{ question.question_help }}</p>
 <select name="{{question.get_reference()}}">
-<option value="null" selected="">Choose a response</option>
+<option value="" selected="">Choose a response</option>
 {% for part in question.parts %}
     <option value="{{part}}" id="{{ question.get_reference() ~ '_' ~ loop.index0 }}" {% if question.get_reference() in user_response and user_response[question.get_reference()] == part %}selected="selected"{% endif %}>{{part}}</option>
 {% endfor %}


### PR DESCRIPTION
**What**
The dropdown question was passing null as it's value. This meant it could never be set as mandatory as null was being treated as a non-empty string. This pull requests changes it to an empty string so that it can be validate correctly.

**How to test**
1. Launch the survey runner
2. Browse to the debug survey http://127.0.0.1:5000/questionnaire/1?debug=True
3. Do not enter a response for the drop down question
4. Check that the validation kicks in and the question is flagged as required.

**Who can test**
Anyone but @warren-methods
