### PR TITLE
DIGEQ-54 retry cassandra connection

### DIFF
--- a/srunner.py
+++ b/srunner.py
@@ -26,7 +26,8 @@ with app.app_context():
             cassandra_session.set_keyspace("sessionstore")
             break
         except NoHostAvailable:
-            if attempt < 5:
+            if attempt < 30:
+                print "Trying cassandra connection, attempt number ", attempt
                 attempt += 1
                 time.sleep(attempt)
             else:


### PR DESCRIPTION
**What**
Retry the cassandra connection 30 times on start up, each time increasing the wait by 1 second. This should solve the docker timing issue.

**How to test**
Bring the environment using `docker-compose up` in the author application

**Who can review**
Anyone apart from @warren-methods
