### PR TITLE
Update to new version of texttable.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ requests==2.6.2
 six==1.10.0
 SQLAlchemy==1.0.8
 SQLAlchemy-Utils==0.31.0
-texttable==0.8.3
+texttable==0.8.4
 Unidecode==0.4.18
 validators==0.9
 websocket-client==0.32.0


### PR DESCRIPTION
_What_

This PR bumps the version of texttable that we use as it appears the pypi version has been renamed and thus when doing a fresh deployment, pip fails on install of texttable as it can't find the library in PyPi.

_How to test_
1. Checkout branch 
2. Activate virtualenv
3. pip install -r requirements.txt --upgrade --force
4. Run tests

This scenario should be covered by the Travis CI run - so that may be enough evidence to merge this PR

_Who_

Anyone but @dhilton 
