### PR TITLE
DIGEQ-133 Store user responses in S3 bucket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2.7.10
 
 RUN mkdir /opt/eq-survey-runner
-add ./requirements.txt /opt/eq-survey-runner/requirements.txt
+ADD ./requirements.txt /opt/eq-survey-runner/requirements.txt
 RUN pip install -r /opt/eq-survey-runner/requirements.txt
 ADD . /opt/eq-survey-runner
 WORKDIR /opt/eq-survey-runner

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ __Mac__
 
 1. Install docker-toolkit: https://www.docker.com/toolbox
 2. Install Virtualbox > 4.3.28 : https://www.virtualbox.org/wiki/Downloads
-2. Once installed, run the following:
+3. Once installed, run the following:
 ```
 docker-machine create default
 eval "$(docker-machine env default)"
@@ -49,6 +49,10 @@ environment with the correct values to use docker as a linux system would.
 Everytime you start or stop a docker-machine VM instance, you need to
 re-run `eval "$(docker-machine env default)"`.
 
+__AWS__
+The survey runner deposits submitted responses in an S3 bucket. To be able to do this it needs to know your aws details.
+PIP will install the aws cli for you, however you need to run `aws configure` in order to place the necessary files in
+your home directory.
 
 __Ubuntu__
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ web:
    - "8080:8080"
   volumes:
    - .:/opt/eq-survey-runner
+   - ~/.aws:/root/.aws
   environment:
     - MODE=dev
   links:

--- a/questionnaireManager.py
+++ b/questionnaireManager.py
@@ -7,6 +7,8 @@ from collections import OrderedDict
 class QuestionnaireManager(object):
 
     def __init__(self, questionnaire_schema, questionnaire_state):
+        self.questionnaire_id = None
+        self.survey_id = None
         self.title = None
         self.question_index = 0
         self.started = False
@@ -23,7 +25,8 @@ class QuestionnaireManager(object):
             self._load_questionnaire_state(questionnaire_state)
 
     def _load_questionnaire_data(self, questionnaire_data):
-
+        self.survey_id = questionnaire_data['survey_id']
+        self.questionnaire_id = questionnaire_data['questionnaire_id']
         self.title = questionnaire_data['title']
         self.overview = questionnaire_data['overview']
         for index, schema in enumerate(questionnaire_data['questions']):
@@ -127,6 +130,18 @@ class QuestionnaireManager(object):
             'warningsAccepted': self.warningsAccepted,
             'justifications': self.justifications
         }
+
+    def get_submitted_data(self):
+        if self.completed:
+            return {
+                'surveyId': self.survey_id,
+                'questionnaireId': self.questionnaire_id,
+                'responses': self.responses,
+                'warningsAccepted': self.warningsAccepted,
+                'justifications': self.justifications
+            }
+        else:
+            return {}
 
     def store_response(self, response):
         for ref in response.keys():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
+awscli==1.9.9
 backports.ssl-match-hostname==3.4.0.2
 bleach==1.4.2
 bleach-whitelist==0.0.7
+boto3==1.2.2
 cassandra-driver==2.7.2
 decorator==4.0.4
 docker-compose==1.4.2

--- a/srunner.py
+++ b/srunner.py
@@ -185,7 +185,7 @@ def questionnaire_viewer(questionnaire_id, quest_session_id=None):
 
         if q_manager.started:
             if q_manager.completed:
-                submit_data(quest_session_id, q_manager.get_questionnaire_state());
+                submit_data(quest_session_id, q_manager.get_submitted_data());
                 return render_template('survey_completed.html',
                                         responses=q_manager.get_responses(),
                                         questionnaire=q_manager,

--- a/test_fixtures/empty-rule-schema.json
+++ b/test_fixtures/empty-rule-schema.json
@@ -1,4 +1,6 @@
 {
+    "survey_id": "0001",
+    "questionnaire_id": "1234",
     "overview": "This is a questionnaire to test stuff",
     "title": "welcome to my survey about crayons",
     "questionnaire_title": "Hope",

--- a/test_fixtures/groups.json
+++ b/test_fixtures/groups.json
@@ -1,5 +1,7 @@
 {
-  "overview": "This is a questionnaire to test stuff",
+  "survey_id": "0001",
+  "questionnaire_id": "1234",
+  "overview":"This is a questionnaire to test stuff",
   "title": "welcome to my survey about crayons",
   "questionnaire_title": "Hope",
   "questions": [{

--- a/test_fixtures/starwars.json
+++ b/test_fixtures/starwars.json
@@ -1,4 +1,5 @@
 {
+  "survey_id": "0001",
   "questionnaire_id": "1234",
   "overview": "This is census survey for the population to discuss their views on Star Wars",
   "title": "Census 2021",
@@ -252,7 +253,6 @@
         "type": "warning",
         "message": "you could always change it to 10"
       }]
-
     }],
     "id": 2,
     "questionText": "The New Film",

--- a/test_fixtures/test_survey.json
+++ b/test_fixtures/test_survey.json
@@ -1,4 +1,6 @@
 {
+  "survey_id": "0001",
+  "questionnaire_id": "1234",
   "overview":"This is a questionnaire to test stuff",
   "title": "welcome to my survey about crayons",
   "questionnaire_title":"Hope",


### PR DESCRIPTION
**What**
This change allows the user's responses in be stored in an s3 bucket called 'digitaleq' once the survey has been completed and submitted. The responses are stored in a JSON format along with the survey id and questionnaire id.

To achieve this we're using the Amazon SDK for Python (Boto3), this requires that all aws keys are set up correctly in your ~/.aws directory. Following the steps below to do this.

**Pre-requisites**
1. Run pip install -r requirements to install Boto3 and the AWS cli.
2. Run `aws configure` to setup your amazon keys. 

**How to test**
1. Checkout this branch
2. Run the survey runner
3. Complete the debug questionnaire
4. Log into your amazon account and check that a response for your session id is available in the s3 bucket 'digitaleq'

**Who can review**
Anyone apart from @warren-methods.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/onsdigital/eq-survey-runner/60)

<!-- Reviewable:end -->
