### PR TITLE
Removing placeholder text from Justification

### DIFF
--- a/templates/questions/question.html
+++ b/templates/questions/question.html
@@ -13,7 +13,7 @@
           <input type="checkbox" name="warning_{{question.get_reference()}}" value="true" {% if question.get_reference() in user_warningsAccepted %}checked="checked"{% endif %}>
           <p>You can accept this warning and proceed by checking the box</p>
           <p>Please provide a short explanation for accepting the warning</p>
-          <input type="text" placeholder="e.g This question was not relevant to me because..." name="justification_{{question.get_reference()}}" value="{{user_justification[question.get_reference()] or ''}}">
+          <input type="text" name="justification_{{question.get_reference()}}" value="{{user_justification[question.get_reference()] or ''}}">
         </div>
       {% endfor %}
   {% endif %}


### PR DESCRIPTION
**What**
Removing the place holder text from the justification box.

**How to test**
1. Run the debug survey
2. Enter an invalid value for favourite character (e.g· asdasdsadasdasdasdasdasdasdas)
3. Submit
4. Check the justification box does not contain placeholder text

**Who can review**
Anyone apart from @warren-methods
