### PR TITLE
DIGEQ-133 adding a gateway page to access the survey runner

### DIFF
--- a/srunner.py
+++ b/srunner.py
@@ -35,9 +35,15 @@ def _load_fixture(filename):
     return q_data
 
 
-@app.route('/')
+@app.route('/', methods=('GET', 'POST'))
 def hello():
-    return render_template('index.html')
+    if request.method == 'POST':
+        questionnaire_id = request.form.get("questionnaire_id")
+        session_id = request.form.get("session_id")
+        new_url = request.base_url + 'questionnaire/' + questionnaire_id + '/' + session_id + '/'
+        return redirect(new_url)
+    else:
+        return render_template('index.html')
 
 
 @app.route('/autosave/<int:questionnaire_id>/<quest_session_id>', methods=['POST'])

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,1 +1,37 @@
-Hello world!
+<html>
+<head><title>DigitalEQ Gateway</title>
+<style>
+    body, button, input, select, textarea {
+        font-family: "open-sans-n4", "open-sans", sans-serif;
+    }
+    body {
+        position: fixed;
+        top: 10%;
+        left: 50%;
+        transform: translate(-50%, -10%);
+    }
+    label {
+        width: 150px;
+        display: inline-block;
+    }
+</style>
+</head>
+<body>
+
+<h1>Digital EQ Gateway</h1>
+<form method="post">
+    <p><label for="questionnaire_id">Questionnaire ID</label>
+        <input id="questionnaire_id" type="text" name="questionnaire_id"/>
+    </p>
+
+    <p><label for="session_id">Session ID</label>
+        <input id="session_id" type="text" name="session_id"/>
+    </p>
+    <p>
+        <label for="submit"> </label>
+        <input id="submit" type="submit" value="Proceed">
+    </p>
+</form>
+</body>
+</html>
+


### PR DESCRIPTION
**What**
Creating a page that allows the user to enter a questionnaire id and a session id. This page will then redirect the user to the digital eq survey runner. The idea of this page is to simulate an external system accessing Digital EQ.  I've reused the index.html page as it wasn't being used for anything apart from outputting 'HelloWorld'

**How to test**
1. Start the survey runner
2. Browse to http://localhost:8080/
3. Enter a questionnaire id and session id (the questionnaire id must exist)
4. Click proceed
5. You should be redirected to the survey runner main page

**Who can review**
Anyone apart from @warren-methods
