### PR TITLE
Add demo respondent portal functionality

### DIFF
--- a/srunner.py
+++ b/srunner.py
@@ -52,6 +52,10 @@ def hello():
     else:
         return render_template('index.html')
 
+@app.route('/feedback', methods=('GET', 'POST'))
+def feedback():
+    return render_template('feedback.html')
+
 
 @app.route('/autosave/<int:questionnaire_id>/<quest_session_id>', methods=['POST'])
 def autosave(questionnaire_id, quest_session_id):

--- a/templates/feedback.html
+++ b/templates/feedback.html
@@ -1,0 +1,57 @@
+<html>
+<head><title>Respondent portal</title>
+<style>
+    body, button, input, select, textarea {
+        font-family: "open-sans-n4", "open-sans", sans-serif;
+    }
+    body {
+
+    }
+    label {
+        width: 250px;
+        display: inline-block;
+    }
+    header {
+        width: 100%;
+        background-color: green;
+        color: white;
+        margin:0;
+        padding:25px;
+    }
+    section {
+        margin-left: 200px;
+
+
+    }
+</style>
+</head>
+<body>
+<header>
+<h1>Respondent portal</h1>
+</header>
+<br>
+<section>
+<h1>Give feedback</h1>
+
+<form method="post">
+    <p><label for="feedback">Overall, how did you feel about the service you received today?</label><br />
+    <br>
+        <input type="radio" name="group1" value="Milk">Very satisfied<br>
+        <input type="radio" name="group1" value="Butter">Satisfied <br>
+        <input type="radio" name="group1" value="Butter">Niether satisfied nor dissatified<br>
+        <input type="radio" name="group1" value="Butter">Dissatified<br>
+        <input type="radio" name="group1" value="Butter">Very dissatified<br>
+    </p>
+
+    <p><label for="feedback_data">How could we improve this service?</label><br><br>
+        <input id="session_id" type="text" name="session_id"/>
+    </p>
+    <p>
+        <label for="submit"> </label>
+        <input id="submit" type="submit" value="Send feedback">
+    </p>
+</form>
+</section>
+</body>
+</html>
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,24 +1,34 @@
 <html>
-<head><title>DigitalEQ Gateway</title>
+<head><title>Respondent portal</title>
 <style>
     body, button, input, select, textarea {
         font-family: "open-sans-n4", "open-sans", sans-serif;
     }
     body {
-        position: fixed;
-        top: 10%;
-        left: 50%;
-        transform: translate(-50%, -10%);
+
     }
     label {
-        width: 150px;
+        width: 250px;
         display: inline-block;
+    }
+    header {
+        width: 100%;
+        background-color: green;
+        color: white;
+        margin:0;
+        padding:25px;
+    }
+    section {
+        margin-left: 200px;
+
+
     }
 </style>
 </head>
 <body>
-
-<h1>Digital EQ Gateway</h1>
+<header>
+<h1>Respondent portal</h1>
+</header>
 <form method="post">
     <p><label for="questionnaire_id">Questionnaire ID</label>
         <input id="questionnaire_id" type="text" name="questionnaire_id"/>

--- a/templates/questions/QuestionGroup.html
+++ b/templates/questions/QuestionGroup.html
@@ -10,6 +10,5 @@
 {% endblock pageBody %}
 
 {% block actions %}
-<!--<input type="button" class="btn exit" value="Save and exit">-->
 <input type="submit" class="btn continue" name="next" value="Save and continue">
 {% endblock actions %}

--- a/templates/survey_completed.html
+++ b/templates/survey_completed.html
@@ -55,3 +55,7 @@
 
 
 {% endblock content %}
+
+{% block actions %}
+  <a href="/feedback" class="btn continue">Return to portal and give feedback</a>
+{% endblock actions %}

--- a/templates/survey_intro.html
+++ b/templates/survey_intro.html
@@ -33,7 +33,7 @@
 <p>Dear Sir or Madam,</p>
 <p>Please find below the July 2015 questionnaire for the welcome to my survey about crayons. Your data should cover the period 3 July 2015. If actual figures are not available, please provide informed estimates.</p>
 <p>The information supplied is used to produce a comprehensive and reliable measure of job vacancies across the economy. Results are published in the monthly Labour Market Statistical Bulletin and used by the Treasury and the Bank of England as a valuable indicator of labour demand. We guarantee that while your employment is less than 10, you will receive no more than 15 monthly questionnaires for this one ONS business survey. You must complete and return all questionnaires on time, after which you will be excluded from all business surveys for at least 3 years. The Annual Survey of Hours and Earnings is not covered by this guarantee.</p>
-<p>You are required by law to complete this questionnaire. If you do not complete and return this questionnaire by 10th July 2015, penalties may be incurred (under section 4 of the Statistics of Trade Act 194 7). All the information you provide is kept strictly confidential. It is illegal for us to reveal your data or identify your business to unauthorised persons. Thank you for your co-operation</p>
+<p>You are required by law to complete this questionnaire. If you do not complete and return this questionnaire by 10th July 2015, penalties may be incurred (under section 4 of the Statistics of Trade Act 1947). All the information you provide is kept strictly confidential. It is illegal for us to reveal your data or identify your business to unauthorised persons. Thank you for your co-operation</p>
 <p><b>Office for National Statistics</b></p>
 {% endblock pageBody %}
 


### PR DESCRIPTION
**What**

To help illustrate our integration strategy, we've started to create a demo respondent management mockup to prototype the integration between a respondent portal and EQ.

**How to test**

Create a new environment using this and complete a survey, then press the return to portal and give feedback button.

**Who can test?**
Anyone but @dhilton 
