### PR TITLE
DIGEQ-228 always show visited sections regardless of whether there are skipping rules

### DIFF
--- a/questionnaireManager.py
+++ b/questionnaireManager.py
@@ -270,8 +270,7 @@ class QuestionnaireManager(object):
         for history in self.history:
             question = self.get_question_by_reference(history['reference'])
 
-            if not question.skipping:
-                history_with_question_objects[question] = history['valid']
+            history_with_question_objects[question] = history['valid']
 
         return history_with_question_objects
 

--- a/templates/survey_completed.html
+++ b/templates/survey_completed.html
@@ -8,7 +8,6 @@
 {% if questionnaire.get_history() %}
     <ul class="summary-screen">
         {% for section in questionnaire.questions %}
-        {% if not section.skipping %}
         <li class="summary-screen-list">
           <div>
             <div class="summary-screen-header">
@@ -60,8 +59,6 @@
               {% endfor %}
 
         </li>
-        {% endif %}
-
 
         {% endfor %}
 </ul>


### PR DESCRIPTION
**What**
Fixes the issue with multiple routing rules. As agreed we'll just show all visited history regardless of whether a new jump rule means you should skip it.

**How to test**
1. Run the debug survey
2. For section 1, question 2, select any film apart from episode 1
3. Complete all sections of the survey
4. Go back and change your answer for section 1 q2 to episode 1
5. This should now skip section 2
6. Complete the survey and check the history remains intact. I.e history for section 2 is still displayed.

**Who can review**
Anyone apart from @warren-methods
