### PR TITLE
Use the survey registry rather than eq-author to get questionnaire schemas

### DIFF
--- a/srunner.py
+++ b/srunner.py
@@ -23,7 +23,7 @@ app.logger.addHandler(file_handler)
 
 # @TODO change this env variable
 app.secret_key = 'A0Zr98j/3yX R~XHH!jmN]LWX/,?RT'
-app.survey_registry_url = os.environ.get('SURVEY_REGISTRY_URL', 'http://localhost:8000/')
+app.survey_registry_url = os.environ.get('SURVEY_REGISTRY_URL', 'http://localhost:8081/')
 
 
 # store the responses in a S3 bucket
@@ -68,7 +68,7 @@ def autosave(questionnaire_id, quest_session_id):
 
 
 def get_form_schema(questionnaire_id):
-    qurl = app.survey_registry_url + '/surveys/api/questionnaire/' + str(questionnaire_id) + '/'
+    qurl = app.survey_registry_url + '/' + str(questionnaire_id)
     form_schema = requests.get(qurl)
     return form_schema.content
 


### PR DESCRIPTION
**What**
Once this change is commit, we can change the survey runner to point at the survey registry rather than the author application

https://github.com/ONSdigital/eq-survey-registry/pull/1

**How to test**

**Who can review**
Anyone apart from @warren-methods
